### PR TITLE
SVE-42: harden lifecycle + pause API, ship ESM/CJS, fix package.json & README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,89 +1,118 @@
 # Simple Shader Component
 *by [svey](https://svey.xyz)*
 
-[![GitHub release (latest by date including pre-releases)](https://img.shields.io/github/v/tag/svey-xyz/simple-shader-component?include_prereleases&sort=semver)](https://GitHub.com/svey-xyz/simple-shader-component/tags/)
+[![npm](https://img.shields.io/npm/v/@svey-xyz/simple-shader-component)](https://www.npmjs.com/package/@svey-xyz/simple-shader-component)
 [![GitHub commits](https://badgen.net/github/commits/svey-xyz/simple-shader-component)](https://GitHub.com/svey-xyz/simple-shader-component/commit/)
-[![GNU license v3.0](https://img.shields.io/badge/License-GNU-green.svg)](https://github.com/svey-xyz/simple-shader-component/LICENSE)
-[![Bundle size](https://img.shields.io/bundlejs/size/simple-shader-component)](https://github.com/svey-xyz/simple-shader-component)
+[![GPL-3.0 license](https://img.shields.io/badge/License-GPL--3.0-green.svg)](https://github.com/svey-xyz/simple-shader-component/blob/main/LICENSE)
 
 ## Description
-This library provides a simple to use webgl shader component, with included framework wrappers and strong typing. Shaders are powerful tools and can be used to add a lot of visual interest to your web project. However, setting-up many shader tools can be complicated and add a large bundle to your project, this library provides a simple core package to make rendering a shader in your DOM incredibly easy.
+A simple to use WebGL shader component, with included framework wrappers and strong typing. Shaders are powerful tools and can add a lot of visual interest to a web project, but most shader tooling is complicated and adds a large bundle. This library is a tiny, zero-dependency core for rendering a GLSL shader straight into the DOM.
 
 ## Core Concepts
 ### Why
-While libraries like [three.js](https://threejs.org/) are amazing, not every project requires all the provided features. That's where simple-shader-component comes in; this is a zero-dependency library that provides a simple to use component for rendering GLSL shaders on the web.
+While libraries like [three.js](https://threejs.org/) are amazing, not every project needs all of those features. `simple-shader-component` is a zero-dependency library that provides a simple component for rendering GLSL shaders on the web.
 
-## Installation & Usage
-```zsh
-bun i simple-shader-component
+### What it gives you (and what it doesn't)
+This package is a **primitive, not a kit** — it renders a full-screen quad and runs a render loop. It deliberately ships **no shaders** and **no automatic uniforms**; you provide the GLSL and feed any uniforms yourself via hooks.
+
+The GLSL contract:
+
+- **WebGL1 / GLSL ES 1.00.** The context is created with `getContext('webgl')`.
+- The vertex shader **must** declare the attribute `attribute vec2 a_position;` — geometry is a hardcoded full-screen quad (two triangles in clip space). No other attributes are provided.
+- There are **no automatic uniforms.** Common ones like `u_time` and `u_resolution` are *not* injected — declare them in your shader and update them from hooks (see below). `u_time` is typically driven from a `LOOP` hook via `shader.getElapsedTime()`; `u_resolution` from a `RESIZE` hook.
+
+## Installation
+```sh
+npm install @svey-xyz/simple-shader-component
+# or: bun add @svey-xyz/simple-shader-component
+# or: pnpm add @svey-xyz/simple-shader-component
 ```
 
-The base class and types are all exported from the root of the package.
-Framework wrappers are available under sub exports.
+`react` is a peer dependency (`^17 || ^18 || ^19`). The package ships both ESM and CJS builds with type declarations.
+
+The core class and types are exported from the package root; framework wrappers live under sub-paths:
 ```ts
-import { SimpleShaderCanvas } from 'simple-shader-component/react'
-```
-***Note**: Right now only the React wrapper is included. If there's interest, or if my workflow requires it, I will add additional wrappers.*
-
-### Hooks
-Hooks can be added to any of the class methods, to add a hook you can pass it on construction or using the exposed add hook method.
-
-```tsx
-import { Shader, MethodName } from 'simple-shader-component' // import types from base package
-
-const hook = {
-	methodName: MethodName.RENDER,
-	hook: (shader: Shader) => void
-}
-
-Shader.addHook(hook) // use addHook method
-<SimpleShaderCanvas args={{ hooks:[hook] }} /> // or pass on construction
+import { Shader, MethodName, type UniformValue } from '@svey-xyz/simple-shader-component'
+import { SimpleShaderCanvas } from '@svey-xyz/simple-shader-component/react'
 ```
 
-### Basic Usage
-'use client' directive is required to set hooks. If you're not using hooks it can be done in a server component.
+## React usage
+`'use client'` is required when you pass hooks (hooks are functions, so they can't cross the server/client boundary).
 
 ```tsx
 'use client'
 
-import { SimpleShaderCanvas } from 'simple-shader-component/react'
-import { Shader, UniformValue } from 'simple-shader-component'
+import { SimpleShaderCanvas } from '@svey-xyz/simple-shader-component/react'
+import { MethodName, type Shader, type UniformValue } from '@svey-xyz/simple-shader-component'
+import { useMemo } from 'react'
 
-// Define shaders as strings, or import from a glsl file with a loader
-import { frag, vert } from '.your-custom-shaders'
+// Provide your own GLSL. The vertex attribute MUST be `a_position` (vec2).
+import { frag, vert } from './your-custom-shaders'
 
-// Example uniform to track elapsed time in the shader
-const uniforms: Array<UniformValue> = [
-	{
-		name: 'u_time',
-		type: "float",
-		value: 0.0
-	}
-]
+export const Background = () => {
+	// Memoize args — a new object reference recreates the WebGL instance.
+	const args = useMemo(() => {
+		const uniforms: UniformValue[] = [{ name: 'u_time', type: 'float', value: 0 }]
 
-export const Test = () => {
-	// Simple hook to update a uniform
-	const loopLogic = (shader: Shader) => {
-		const uTime: UniformValue = {
-			name: 'u_time',
-			type: 'float',
-			value: shader.getElapsedTime() // Uses exposed method of shader
+		// Drive u_time every frame from a LOOP hook.
+		const loopHook = {
+			methodName: MethodName.LOOP,
+			hook: (shader: Shader) => {
+				shader.setUniform({ name: 'u_time', type: 'float', value: shader.getElapsedTime() })
+			},
 		}
-		shader.setUniform(uTime)
-	}
 
-	// Define which method to attach the hook to
-	const loopHook = {
-		methodName: MethodName.LOOP,
-		hook: loopLogic
-	}
+		return { vertShader: vert, fragShader: frag, uniforms, hooks: [loopHook] }
+	}, [])
 
-	// Render component with args
-	return <SimpleShaderCanvas args={{ uniforms: uniforms, fragShader: frag, vertShader: vert, hooks: [loopHook] }} />
+	return <SimpleShaderCanvas args={args} />
 }
 ```
 
-*Coming Soon*
-- improved documentation
-- screenshots & examples of how shaders as a component can be used to add visual interest
-- roadmap
+### `<SimpleShaderCanvas>` props
+| Prop | Type | Default | Description |
+| --- | --- | --- | --- |
+| `args` | `ShaderArgs` | — | Shader configuration (see below). **Memoize it** — a new reference tears down and recreates the instance. |
+| `paused` | `boolean` | `false` | Pause/resume the render loop **without unmounting**. Toggling it does not recreate the WebGL context. Useful for pausing offscreen or on tab-hidden. |
+| `respectReducedMotion` | `boolean` | `false` | When `true`, the loop won't auto-start if the user has `prefers-reduced-motion: reduce` (a single static frame is still rendered). |
+
+All other `<canvas>` attributes (`className`, `style`, `aria-hidden`, `id`, …) are forwarded to the canvas. The canvas defaults to `width: 100%` and `aria-hidden` (it's decorative); pass `aria-hidden={false}` to override. The component is unstyled beyond that — size it with your own CSS.
+
+### `args` (`ShaderArgs`)
+| Field | Type | Default | Description |
+| --- | --- | --- | --- |
+| `vertShader` | `string` | — | Vertex shader source (GLSL ES 1.00). Must declare `attribute vec2 a_position;`. |
+| `fragShader` | `string` | — | Fragment shader source (GLSL ES 1.00). |
+| `uniforms` | `UniformValue[]` | — | Initial uniforms, applied before the first paint. |
+| `hooks` | `{ methodName, hook }[]` | — | Lifecycle hooks (see below). |
+| `loadedClass` | `string` | `'loaded'` | Class added to the canvas once initialized. |
+| `autoStart` | `boolean` | `true` | Start the render loop inside `init()`. Set `false` to render a single static frame and start the loop later via `shader.startLoop()`. |
+
+## Hooks
+Hooks attach logic to a lifecycle method. Pass them on construction (via `args.hooks`) or add them later with `shader.addHook(...)`.
+
+```ts
+import { MethodName, type Shader } from '@svey-xyz/simple-shader-component'
+
+const hook = {
+	methodName: MethodName.RENDER,
+	hook: (shader: Shader) => { /* ... */ },
+}
+```
+
+`MethodName`: `INIT`, `LOOP`, `RENDER`, `RESIZE`, `INPUT`, `TOUCH`.
+
+## Imperative API (`Shader`)
+The `Shader` instance (and its `domHandler` base) expose:
+
+- `init()` — compile, size, render and (unless `autoStart` is `false`) start the loop.
+- `startLoop(refreshRate?)` / `stopLoop()` — start or pause the render loop without tearing anything down.
+- `destroy()` — stop the loop, cancel pending frames, remove the window/canvas listeners and release GL resources. **Idempotent.** The React wrapper calls this automatically on unmount and when `args` change.
+- `getElapsedTime()` — seconds since the loop started.
+- `getUniform(name)` / `setUniform({ name, type, value })`.
+
+## Lifecycle & cleanup
+The React wrapper owns the instance lifecycle: it creates a `Shader` on mount, calls `destroy()` on unmount or when `args` change, and pauses/resumes via the `paused` prop. If you use the core `Shader` class directly, **call `destroy()`** when you're done — otherwise the render loop and event listeners leak.
+
+## License
+GPL-3.0 — see [LICENSE](./LICENSE).

--- a/build.ts
+++ b/build.ts
@@ -1,29 +1,32 @@
-const ESM = await Bun.build({
-	entrypoints: ["./src/core/index.ts", "./src/react/index.tsx"],
+// Builds the library to both ESM (`.js`) and CJS (`.cjs`) so the `import` and
+// `require` conditions in package.json#exports both resolve to real files.
+// `react` / `react-dom` stay external (provided by the consumer as peers).
+const entrypoints = ["./src/core/index.ts", "./src/react/index.tsx"];
+
+const common = {
+	entrypoints,
 	outdir: "./dist",
-	target: "browser",
-	format: "esm",
-	external: ["react"],
-	sourcemap: "linked",
-	minify: true
-});
+	target: "browser" as const,
+	external: ["react", "react-dom"],
+	sourcemap: "linked" as const,
+	minify: true,
+	define: { "process.env.NODE_ENV": JSON.stringify("production") },
+};
 
-// const CJS = await Bun.build({
-// 	entrypoints: ["./src/core/index.ts", "./src/react/index.tsx"],
-// 	outdir: "./dist",
-// 	target: "browser",
-// 	format: "cjs",
-// 	external: ["react"],
-// 	sourcemap: "linked",
-// 	minify: true
-// });
+const esm = await Bun.build({ ...common, format: "esm" });
+const cjs = await Bun.build({ ...common, format: "cjs", naming: "[dir]/[name].cjs" });
 
-if (!ESM.success) {
-	console.error("Build failed");
-	for (const message of [...ESM.logs]) {
-		// Bun will pretty print the message object
-		console.error(message);
+let failed = false;
+for (const result of [esm, cjs]) {
+	if (!result.success) {
+		failed = true;
+		console.error("Build failed");
+		for (const message of result.logs) {
+			console.error(message);
+		}
 	}
 }
 
-export {  }
+if (failed) process.exit(1);
+
+export {};

--- a/package.json
+++ b/package.json
@@ -5,11 +5,16 @@
   "keywords": [
     "glsl",
     "shader",
-    "component"
+    "component",
+    "webgl",
+    "react"
   ],
-  "version": "1.0.2",
-  "main": "dist/core/index.js",
-  "module": "dist/core/index.esm.js",
+  "version": "1.2.0",
+  "license": "GPL-3.0",
+  "type": "module",
+  "main": "dist/core/index.cjs",
+  "module": "dist/core/index.js",
+  "types": "dist/core/index.d.ts",
   "publishConfig": {
     "registry": "https://registry.npmjs.org"
   },
@@ -28,8 +33,8 @@
   ],
   "devDependencies": {
     "@types/bun": "^1.1.13",
-    "@types/react": "^18.3.12",
-    "@types/react-dom": "^18.3.1",
+    "@types/react": "^19.2.0",
+    "@types/react-dom": "^19.2.0",
     "ts-node": "^10.9.2",
     "tslib": "^2.8.1",
     "typescript": "^5.6.3"
@@ -39,22 +44,20 @@
   },
   "exports": {
     ".": {
-      "require": "./dist/core/index.js",
+      "types": "./dist/core/index.d.ts",
       "import": "./dist/core/index.js",
-      "types": "./dist/core/index.d.ts"
+      "require": "./dist/core/index.cjs"
     },
     "./react": {
-      "require": "./dist/react/index.js",
+      "types": "./dist/react/index.d.ts",
       "import": "./dist/react/index.js",
-      "types": "./dist/react/index.d.ts"
+      "require": "./dist/react/index.cjs"
     }
   },
   "scripts": {
-		"clean": "rm -rf dist",
+    "clean": "rm -rf dist",
     "build:library": "bun ./build.ts",
     "build:types": "bunx tsc",
     "build": "bun run clean && bun build:library && bun build:types && cp -R ./src/types ./dist/types"
-  },
-  "type": "module",
-  "types": "dist/types/index.d.ts"
+  }
 }

--- a/src/core/domHandler.ts
+++ b/src/core/domHandler.ts
@@ -8,14 +8,22 @@ export enum MethodName {
 }
 
 export class domHandler {
+	private static readonly canvasEvents = [
+		'click', 'mousedown', 'mouseup', 'mouseleave', 'mouseenter',
+		'mousemove', 'touchstart', 'touchend', 'touchmove'
+	] as const;
+
 	private _container: HTMLCanvasElement;
 	private sectionSize: { width: number, height: number } = { width: 0, height: 0 };
 	private loopActive: boolean = false;
+	private destroyed: boolean = false;
+	private refreshRate: number = 0;
 	private timer: any;
 	private touch: boolean = false;
 	private ongoingTouches: Array<Touch> = [];
 	private inputHandler: (e: Event) => void;
 	private resizeHandler: (e: Event) => void;
+	private debouncedResize: (e: Event) => void;
 
 	// Clock properties
 	private startTime: number = 0; // Time when the clock starts
@@ -26,20 +34,26 @@ export class domHandler {
 
 		// initialize listeners
 		this.inputHandler = this.handleInput.bind(this);
-		this.container.addEventListener('click', this.inputHandler, { passive: true });
-		this.container.addEventListener('mousedown', this.inputHandler, { passive: true });
-		this.container.addEventListener('mouseup', this.inputHandler, { passive: true });
-		this.container.addEventListener('mouseleave', this.inputHandler, { passive: true });
-		this.container.addEventListener('mouseenter', this.inputHandler, { passive: true });
-		this.container.addEventListener('mousemove', this.inputHandler, { passive: true });
-		this.container.addEventListener('touchstart', this.inputHandler, { passive: true });
-		this.container.addEventListener('touchend', this.inputHandler, { passive: true });
-		this.container.addEventListener('touchmove', this.inputHandler, { passive: true });
-
 		this.resizeHandler = this.resize.bind(this);
-		window.addEventListener('resize', this.debounce(this.resizeHandler), { passive: true });
+		// Keep the debounced reference so it can be removed in destroy().
+		this.debouncedResize = this.debounce(this.resizeHandler);
+		this.addListeners();
 
 		this.setSize();
+	}
+
+	private addListeners(): void {
+		for (const event of domHandler.canvasEvents) {
+			this.container.addEventListener(event, this.inputHandler, { passive: true });
+		}
+		window.addEventListener('resize', this.debouncedResize, { passive: true });
+	}
+
+	private removeListeners(): void {
+		for (const event of domHandler.canvasEvents) {
+			this.container.removeEventListener(event, this.inputHandler);
+		}
+		window.removeEventListener('resize', this.debouncedResize);
 	}
 
 	// Start the clock
@@ -78,16 +92,47 @@ export class domHandler {
 		this.sectionSize.width = document.documentElement.clientWidth || document.body.clientWidth;
 	}
 
-	protected startLoop = (refreshRate: number = 0) => {
+	/** Subclass cleanup hook. Invoked by destroy() after the loop + listeners are torn down. */
+	protected onDestroy(): void { }
+
+	protected get isDestroyed(): boolean {
+		return this.destroyed;
+	}
+
+	public startLoop = (refreshRate?: number): void => {
+		if (this.destroyed || this.loopActive) return;
+		if (typeof refreshRate === 'number') this.refreshRate = refreshRate;
 		this.loopActive = true;
-		this.mainLoop(refreshRate);
+		this.mainLoop(this.refreshRate);
+	}
+
+	public stopLoop = (): void => {
+		this.loopActive = false;
+		this.cancel();
 	}
 
 	protected mainLoop = (refreshRate: number = 0) => {
-		if (this.loopActive) {
-			this.requestTimeout(() => this.mainLoop(refreshRate), refreshRate);
-			this.loop();
+		if (!this.loopActive || this.destroyed) return;
+		this.requestTimeout(() => this.mainLoop(refreshRate), refreshRate);
+		this.loop();
+	}
+
+	/**
+	 * Tear down the instance: stop the render loop, cancel pending frames and
+	 * remove every window/canvas listener registered in the constructor.
+	 * Idempotent — safe to call more than once.
+	 */
+	public destroy = (): void => {
+		if (this.destroyed) return;
+		this.destroyed = true;
+		this.stopLoop();
+		if (this.timer) {
+			clearInterval(this.timer);
+			this.timer = undefined;
 		}
+		this.removeListeners();
+		this.cancel();
+		this.onDestroy();
 	}
 
 	protected loop(): void {
@@ -100,11 +145,6 @@ export class domHandler {
 	/**
 	 * Returns id for touch from a list.
 	 * Returns -1 if not found.
-	 *
-	 * @param {number} idToFind
-	 * @param {Array<Touch>} ongoingTouches
-	 * @return {*}  {number}
-	 * @memberof domUtils
 	 */
 	protected ongoingTouchIndexById(idToFind: number, ongoingTouches: Array<Touch>): number {
 		for (var i = 0; i < ongoingTouches.length; i++) {
@@ -130,17 +170,13 @@ export class domHandler {
 		// Return a function to run debounced
 		return () => {
 
-			// Setup the arguments
-			let context: any = this;
-			let args: any = arguments;
-
 			// If there's a timer, cancel it
 			if (timeout) {
 				window.cancelAnimationFrame(timeout);
 			}
 			// Setup the new requestAnimationFrame()
 			timeout = window.requestAnimationFrame(() => {
-				this._ScriptUtils.requestTimeout(fn, delay);
+				this.requestTimeout(fn, delay);
 			});
 
 		}
@@ -171,5 +207,3 @@ export class domHandler {
 	protected cancel = this.noop;
 	protected registerCancel = (fn: () => void) => this.cancel = fn;
 }
-
-

--- a/src/core/shader.ts
+++ b/src/core/shader.ts
@@ -1,4 +1,3 @@
-// import { ShaderArgs, UniformValue, ShaderHook } from "../types";
 import { domHandler, MethodName } from "./domHandler";
 import ShaderTypes from "../types"
 
@@ -15,6 +14,7 @@ export class Shader extends domHandler {
 	private vertexBuffer: WebGLBuffer;
 	private uniforms: Array<ShaderTypes.UniformValue> | undefined
 	private loadedClass: string = 'loaded'
+	private autoStart: boolean = true
 
 	constructor(container: HTMLCanvasElement, args: ShaderTypes.ShaderArgs) {
 		super(container);
@@ -24,6 +24,7 @@ export class Shader extends domHandler {
 
 		if (args.uniforms) this.uniforms = args.uniforms
 		if (args.loadedClass) this.loadedClass = args.loadedClass
+		if (args.autoStart === false) this.autoStart = false
 		if (args.hooks) args.hooks.forEach((hook) => {
 			this.addHook(hook.methodName, hook.hook)
 		})
@@ -33,12 +34,16 @@ export class Shader extends domHandler {
 		super.init();
 		this.runHooks(MethodName.INIT);
 
-		this.resize()
-		this.startLoop(60);
-
+		// Apply initial uniforms before the first paint so that a paused /
+		// reduced-motion canvas still renders a correct static frame.
 		this.uniforms?.forEach((uniform) => {
 			this.setUniform(uniform)
 		})
+
+		this.resize()
+
+		if (this.autoStart) this.startLoop(60);
+
 		this.container.classList.add(this.loadedClass)
 	}
 
@@ -110,12 +115,14 @@ export class Shader extends domHandler {
 
 	// Main render loop
 	protected loop(): void {
+		if (this.isDestroyed) return;
 		super.loop();
 		this.runHooks(MethodName.LOOP);
 		this.render();
 	}
 
 	protected render(): void {
+		if (this.isDestroyed) return;
 		const gl = this.gl;
 		this.runHooks(MethodName.RENDER);
 
@@ -194,6 +201,7 @@ export class Shader extends domHandler {
 
 	// Resize handler
 	protected resize(e?: Event): void {
+		if (this.isDestroyed) return;
 		super.resize(e);
 		const { width, height } = this.container.getBoundingClientRect();
 		this.container.width = width;
@@ -206,6 +214,7 @@ export class Shader extends domHandler {
 
 	// Handles input events
 	protected handleInput(e: Event): void {
+		if (this.isDestroyed) return;
 		super.handleInput(e);
 		this.runHooks(MethodName.INPUT);
 
@@ -215,5 +224,19 @@ export class Shader extends domHandler {
 	protected touchStart(e: Event): void {
 		super.touchStart(e);
 		this.runHooks(MethodName.TOUCH);
+	}
+
+	// Release GL resources when the instance is destroyed.
+	protected onDestroy(): void {
+		const gl = this.gl;
+		try {
+			gl.useProgram(null);
+			gl.bindBuffer(gl.ARRAY_BUFFER, null);
+			gl.deleteProgram(this.shaderProgram);
+			gl.deleteBuffer(this.vertexBuffer);
+			gl.getExtension('WEBGL_lose_context')?.loseContext();
+		} catch {
+			// Context may already be lost; nothing else to clean up.
+		}
 	}
 }

--- a/src/react/index.tsx
+++ b/src/react/index.tsx
@@ -1,33 +1,76 @@
 'use client'
 
-import { useRef, useEffect } from "react";
+import { useEffect, useRef, type CanvasHTMLAttributes } from "react";
 import { Shader } from "../core";
-import { ShaderArgs } from "../types";
+import type { ShaderArgs } from "../types";
+
+const prefersReducedMotion = (): boolean =>
+	typeof window !== "undefined" &&
+	typeof window.matchMedia === "function" &&
+	window.matchMedia("(prefers-reduced-motion: reduce)").matches;
+
+export type SimpleShaderCanvasProps = {
+	/** Shader configuration. Memoize this — a new object reference recreates the instance. */
+	args: ShaderArgs;
+	/** Pause the render loop without unmounting. Default false. */
+	paused?: boolean;
+	/** Skip auto-starting the loop when the user prefers reduced motion. Default false. */
+	respectReducedMotion?: boolean;
+} & CanvasHTMLAttributes<HTMLCanvasElement>;
 
 export const SimpleShaderCanvas = ({
 	args,
-	className
-}: {
-	args: ShaderArgs,
-	className?: string
-}) => {
-
+	paused = false,
+	respectReducedMotion = false,
+	className,
+	style,
+	...rest
+}: SimpleShaderCanvasProps) => {
 	const ref = useRef<HTMLCanvasElement>(null);
+	const shaderRef = useRef<Shader | null>(null);
+	const reduceRef = useRef(false);
 
+	// Create the instance for the current canvas + args and tear it down on
+	// unmount or when `args` changes. This is the leak fix: the previous
+	// version never destroyed the instance, leaking a rAF loop + window/canvas
+	// listeners on every re-render (critical under Visual Editing re-renders).
 	useEffect(() => {
-		if (!ref.current) return
+		const canvas = ref.current;
+		if (!canvas) return;
 
-		const ShaderInstance = new Shader(ref.current, args);
-		ShaderInstance.init()
+		const reduce = respectReducedMotion && prefersReducedMotion();
+		reduceRef.current = reduce;
 
-		// return () => ShaderInstance. // TODO: ShaderInstance should be destroyed on return 
-	}, [args]);
+		const shader = new Shader(canvas, { ...args, autoStart: !reduce && !paused });
+		shaderRef.current = shader;
+		shader.init();
+
+		return () => {
+			shader.destroy();
+			shaderRef.current = null;
+		};
+		// `paused` is handled by the effect below so toggling it pauses in place
+		// instead of recreating the WebGL context.
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, [args, respectReducedMotion]);
+
+	// Pause / resume without recreating the instance.
+	useEffect(() => {
+		const shader = shaderRef.current;
+		if (!shader || reduceRef.current) return;
+		if (paused) shader.stopLoop();
+		else shader.startLoop();
+	}, [paused]);
 
 	return (
 		<canvas
 			ref={ref}
-			className={`${className}`}
-			style={{ width: '100%' }}
+			aria-hidden
+			className={className}
+			style={{ width: "100%", ...style }}
+			{...rest}
 		/>
-	)
-}
+	);
+};
+
+export default SimpleShaderCanvas;

--- a/src/types/index.d.ts
+++ b/src/types/index.d.ts
@@ -7,16 +7,18 @@ export type MethodName = _MethodName;
 
 export type ShaderHook = (shader: Shader, ...args: any[]) => void;
 
-/** 
+/**
  * @param logic Logic should be functions passed as strings that take the form (shader: Shader) => void
  * */
 export type ShaderArgs = {
 	vertShader?: string,
 	fragShader?: string,
 	uniforms?: Array<UniformValue>,
-	hooks?: Array<{ methodName: MethodName, hook: ShaderHook }>
+	hooks?: Array<{ methodName: MethodName, hook: ShaderHook }>,
 	/** Default 'loaded' */
-	loadedClass?: string
+	loadedClass?: string,
+	/** Start the render loop automatically inside init(). Default true. */
+	autoStart?: boolean
 }
 
 export type UniformValue = {
@@ -37,4 +39,3 @@ export type UniformType =
 	| "mat2"
 	| "mat3"
 	| "mat4";
-


### PR DESCRIPTION
## Summary

Hardens `@svey-xyz/simple-shader-component` per **SVE-42** so consumers (notably the SVE-31 background-shader wrapper) no longer need leak/pause workarounds. No runtime deps added; `react`/`react-dom` stay peers.

## Fixes

**Lifecycle / leak (primary).** The React wrapper previously never destroyed the `Shader` (literal `// TODO: ShaderInstance should be destroyed on return`), leaking a rAF render loop + a `window` resize listener and ~9 canvas pointer/touch listeners on every re-render — severe under Visual-Editing re-renders.
- `domHandler` gains a public, idempotent `destroy()` that flips a `destroyed` flag, stops the loop, cancels the pending rAF, clears the touch interval and removes **every** listener. Canvas listeners are attached/removed from one `canvasEvents` list; the debounced resize handler is now stored so it can actually be removed.
- `Shader.onDestroy()` releases GL resources (`deleteProgram`/`deleteBuffer`, unbind) and calls `WEBGL_lose_context`. `render`/`resize`/`loop` early-return once destroyed.
- The wrapper's effect now returns `() => shader.destroy()` and re-runs on `args` change.

**Pause API.** Public `startLoop()` / `stopLoop()` (loop no longer double-starts). The wrapper's new `paused` prop pauses/resumes **without unmounting** via a separate effect, so toggling it doesn't recreate the WebGL context.

**Reduced motion.** New `args.autoStart` (default `true`) gates the loop; the wrapper's `respectReducedMotion` prop skips auto-start under `prefers-reduced-motion: reduce` while still painting one static frame.

**`className` bug.** Was `className={`${className}`}`, rendering the literal class `"undefined"` when omitted. Now passed through directly, with full canvas-attribute forwarding and a default `aria-hidden` (decorative; override with `aria-hidden={false}`).

**package.json drift.** `1.0.2` → **`1.2.0`**; real `import`/`require`/`types` export conditions; `main` → `.cjs`, `module` → ESM `.js`, top-level `types` aligned to `dist/core/index.d.ts`; added `license: GPL-3.0`; `@types/react`/`@types/react-dom` → `^19`. (Peer already listed React 19, so kept `^17 || ^18 || ^19`.)

**Build outputs.** `build.ts` now emits **real ESM + CJS** (`.cjs` via `naming`) instead of ESM-only with a dead commented-out CJS block and a `module` field pointing at a nonexistent `index.esm.js`. `react`/`react-dom` external; production JSX via `NODE_ENV` define.

**README.** Correct **scoped** name everywhere (was unscoped `simple-shader-component`), documented the GLSL contract (WebGL1 / GLSL ES 1.00, attribute **must** be `a_position` vec2, hardcoded full-screen quad, **no** auto `u_time`/`u_resolution`), and the new props + imperative API.

**Bonus correctness fix.** The debounced resize called `this._ScriptUtils.requestTimeout(...)` — a property that doesn't exist, so it **threw on every real window resize**. Corrected to `this.requestTimeout(...)`, so resize handling actually works now (and is removed on `destroy()`).

## New public API

```ts
// core
shader.startLoop(refreshRate?)   // start/resume
shader.stopLoop()                // pause in place
shader.destroy()                 // full teardown (idempotent)
ShaderArgs.autoStart?: boolean   // default true

// <SimpleShaderCanvas /> — extends canvas attributes
paused?: boolean                 // pause without unmount
respectReducedMotion?: boolean   // honor prefers-reduced-motion
```

## Verification

Real build is Bun; verified in CI-equivalent tooling:
- `tsc --noEmit` (with `@types/react` 19) — clean.
- `tsc` declaration emit — clean (`destroy`/`startLoop`/`stopLoop` public, props typed).
- `esbuild` ESM **and** CJS bundles of both entrypoints — succeed with `react` external; new API present.

Please run `npm run build` (Bun) before publishing to confirm `dist/` and tag a `>=1.2.0` release. Then SVE-31 can bump to it and drop its leak/pause workarounds.

Related to SVE-31.