### PR TITLE
fix: bind shader program before uniform writes in setUniform

### DIFF
--- a/src/core/shader.ts
+++ b/src/core/shader.ts
@@ -152,6 +152,7 @@ export class Shader extends domHandler {
 
 	/**  Sets a uniform value for the shader */
 	public setUniform(uniform: ShaderTypes.UniformValue): void {
+		if (this.isDestroyed) return;
 		const { name, type, value } = uniform
 		const uLoc = this.gl.getUniformLocation(this.shaderProgram, name);
 
@@ -159,6 +160,13 @@ export class Shader extends domHandler {
 			console.error(`Uniform ${name} not found.`);
 			return;
 		}
+
+		// gl.uniform* writes target the *currently bound* program, not the
+		// program the location came from. Bind ours first; otherwise writes made
+		// before the first render (init defaults) or from LOOP hooks (which run
+		// before render() binds the program) are silently dropped with
+		// GL_INVALID_OPERATION — the classic "u_time never updates" freeze.
+		this.gl.useProgram(this.shaderProgram);
 
 		switch (type) {
 			case "float":

--- a/test/setUniform.test.ts
+++ b/test/setUniform.test.ts
@@ -1,0 +1,55 @@
+import { test, expect } from "bun:test";
+import { Shader } from "../src/core";
+
+// Minimal GL mock that records call order.
+function makeGl(calls: string[]) {
+  const loc = {};
+  return {
+    createShader: () => ({}), shaderSource() {}, compileShader() {},
+    getShaderParameter: () => true, createProgram: () => ({ id: "prog" }),
+    attachShader() {}, linkProgram() {}, getProgramParameter: () => true,
+    createBuffer: () => ({}), bindBuffer() {}, bufferData() {},
+    getUniformLocation: () => loc,
+    useProgram(p: unknown) { calls.push("useProgram"); },
+    uniform1f() { calls.push("uniform1f"); },
+    getAttribLocation: () => 0, vertexAttribPointer() {}, enableVertexAttribArray() {},
+    drawArrays() {}, clear() {}, viewport() {}, getExtension: () => null,
+    deleteProgram() {}, deleteBuffer() {},
+    ARRAY_BUFFER: 0, STATIC_DRAW: 0, VERTEX_SHADER: 0, FRAGMENT_SHADER: 0,
+    COMPILE_STATUS: 0, LINK_STATUS: 0, COLOR_BUFFER_BIT: 0, DEPTH_BUFFER_BIT: 0,
+    STENCIL_BUFFER_BIT: 0, FLOAT: 0, TRIANGLES: 0,
+  };
+}
+
+function makeCanvas(gl: unknown) {
+  return {
+    getContext: () => gl,
+    addEventListener() {}, removeEventListener() {},
+    classList: { add() {} },
+    getBoundingClientRect: () => ({ width: 100, height: 100 }),
+    offsetHeight: 100,
+  } as unknown as HTMLCanvasElement;
+}
+
+test("setUniform binds the program before writing", () => {
+  const calls: string[] = [];
+  const gl = makeGl(calls);
+  // domHandler touches window/document — stub the bits it needs.
+  (globalThis as any).window = { addEventListener() {}, removeEventListener() {}, matchMedia: () => ({ matches: false }) };
+  (globalThis as any).document = { documentElement: { clientWidth: 100 }, body: { clientWidth: 100 } };
+  const shader = new Shader(makeCanvas(gl), { vertShader: "v", fragShader: "f" });
+  shader.setUniform({ name: "u_time", type: "float", value: 1.5 });
+  expect(calls).toEqual(["useProgram", "uniform1f"]);
+});
+
+test("setUniform after destroy is a no-op", () => {
+  const calls: string[] = [];
+  const gl = makeGl(calls);
+  (globalThis as any).window = { addEventListener() {}, removeEventListener() {}, matchMedia: () => ({ matches: false }) };
+  (globalThis as any).document = { documentElement: { clientWidth: 100 }, body: { clientWidth: 100 } };
+  const shader = new Shader(makeCanvas(gl), { vertShader: "v", fragShader: "f" });
+  shader.destroy();
+  calls.length = 0;
+  shader.setUniform({ name: "u_time", type: "float", value: 1.5 });
+  expect(calls).toEqual([]);
+});


### PR DESCRIPTION
## Problem

`gl.uniform*` writes target the **currently bound** program, not the program the `WebGLUniformLocation` came from. `setUniform` relied on `render()` having already bound this instance's program, so two classes of writes were silently dropped with `GL_INVALID_OPERATION`:

1. **Init defaults** — since 7ca791a, `init()` applies `args.uniforms` *before* `resize()` triggers the first `render()`, so no program is bound yet and the defaults never land (a paused/reduced-motion canvas renders with all-zero uniforms, defeating the static-frame intent).
2. **LOOP-hook writes** — `loop()` runs hooks *before* `render()` binds the program. With a single instance this happened to work via the previous frame's binding, but any second instance sharing the canvas/context (the pre-1.2.0 StrictMode double-mount leak) made every hook write hit the *other* instance's program — the "u_time frozen / shader not animating" bug found in sanity-next-clean (SVE-31/42).

## Fix

`setUniform` now calls `gl.useProgram(this.shaderProgram)` before writing, and no-ops after `destroy()` (avoids writes into a lost context). Redundant binds are cheap; correctness no longer depends on call ordering.

## Verification

- `bun test` — new mock-GL tests assert `useProgram` precedes `uniform1f` and that post-destroy writes are no-ops (2 pass).
- `bun run build` — ESM + CJS + declarations emit clean; fix present in all four bundles.