### PR TITLE
Release 1.2.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "webgl",
     "react"
   ],
-  "version": "1.2.3",
+  "version": "1.2.4",
   "license": "GPL-3.0",
   "type": "module",
   "main": "dist/core/index.cjs",

--- a/src/core/shader.ts
+++ b/src/core/shader.ts
@@ -235,6 +235,14 @@ export class Shader extends domHandler {
 	}
 
 	// Release GL resources when the instance is destroyed.
+	//
+	// Deliberately does NOT call WEBGL_lose_context.loseContext(): a canvas
+	// hands out ONE context for its lifetime, so losing it here permanently
+	// kills the canvas for any subsequent Shader (the React wrapper reuses the
+	// same <canvas> when it recreates on args change, and React Strict Mode
+	// dev remounts do the same) — compileShader then no-ops and surfaces as
+	// "Shader compilation error: null". Deleting the program and buffer frees
+	// the GPU resources; the browser reclaims the context with the canvas.
 	protected onDestroy(): void {
 		const gl = this.gl;
 		try {
@@ -242,7 +250,6 @@ export class Shader extends domHandler {
 			gl.bindBuffer(gl.ARRAY_BUFFER, null);
 			gl.deleteProgram(this.shaderProgram);
 			gl.deleteBuffer(this.vertexBuffer);
-			gl.getExtension('WEBGL_lose_context')?.loseContext();
 		} catch {
 			// Context may already be lost; nothing else to clean up.
 		}

--- a/test/core/lifecycle.test.ts
+++ b/test/core/lifecycle.test.ts
@@ -87,3 +87,23 @@ test("destroy removes DOM listeners, releases GL resources and is idempotent", (
 
 	shader.destroy(); // second call must not throw
 });
+
+test("destroy keeps the canvas's context usable — a new Shader on the same canvas works", () => {
+	const gl = makeGl();
+	const canvas = makeCanvas(gl);
+
+	const first = new Shader(canvas, args);
+	first.init();
+	first.destroy();
+
+	// destroy() must not lose the context: the same canvas always returns the
+	// same context, so a lost context would permanently kill every subsequent
+	// instance (React wrapper recreations, Strict Mode dev remounts).
+	expect(gl.calls).not.toContain("loseContext");
+
+	gl.calls.length = 0;
+	const second = new Shader(canvas, args);
+	second.init();
+	expect(gl.calls).toContain("drawArrays"); // renders again on the reused context
+	second.destroy();
+});

--- a/test/helpers/gl.ts
+++ b/test/helpers/gl.ts
@@ -55,8 +55,10 @@ export function makeGl(): RecordingGl {
 		drawArrays: record("drawArrays"),
 		clear() {},
 		viewport: record("viewport"),
-		// teardown
-		getExtension: () => null,
+		// teardown — expose a recording WEBGL_lose_context so suites can assert
+		// destroy() never loses the context (the canvas/context gets reused).
+		getExtension: (name: string) =>
+			name === "WEBGL_lose_context" ? { loseContext: record("loseContext") } : null,
 		deleteProgram: record("deleteProgram"),
 		deleteBuffer: record("deleteBuffer"),
 		// enums


### PR DESCRIPTION
Promote main → production to publish **1.2.4**: `destroy()` no longer calls `WEBGL_lose_context.loseContext()`, fixing the dead canvas / `Shader compilation error: null` on instance recreation (Strict Mode dev remounts, args changes). See #3.